### PR TITLE
Fix: Pass user context to BetService methods

### DIFF
--- a/src/core/bet/bet.controller.ts
+++ b/src/core/bet/bet.controller.ts
@@ -28,23 +28,31 @@ export class BetController {
     return this.betService.create(createBetDto, req.user);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
-  findAll() {
-    return this.betService.findAll();
+  findAll(@Request() req: AuthentificatedRequest) {
+    return this.betService.findAll(req.user);
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.betService.findOne(+id);
+  findOne(@Param('id') id: string, @Request() req: AuthentificatedRequest) {
+    return this.betService.findOne(+id, req.user);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateBetDto: UpdateBetDto) {
-    return this.betService.update(+id, updateBetDto);
+  update(
+    @Param('id') id: string,
+    @Body() updateBetDto: UpdateBetDto,
+    @Request() req: AuthentificatedRequest,
+  ) {
+    return this.betService.update(+id, updateBetDto, req.user);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.betService.remove(+id);
+  remove(@Param('id') id: string, @Request() req: AuthentificatedRequest) {
+    return this.betService.remove(+id, req.user);
   }
 }


### PR DESCRIPTION
Resolved TS2554 errors in bet.controller.ts by ensuring that the partialUser argument is passed to the corresponding BetService methods.

- Added @UseGuards(AuthGuard) to protect routes.
- Injected @Request() req: AuthentificatedRequest to access user details.
- Passed req.user to findAll, findOne, update, and remove methods of BetService.